### PR TITLE
잘못된 도메인 정보 바로잡기

### DIFF
--- a/src/main/java/com/fc8/projectboard/domain/User.java
+++ b/src/main/java/com/fc8/projectboard/domain/User.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 @Getter
 @ToString
 @Table(indexes = {
-        @Index(columnList = "userId"),
+        @Index(columnList = "userId", unique = true),
         @Index(columnList = "email", unique = true),
         @Index(columnList = "createdAt"),
         @Index(columnList = "createdBy")

--- a/src/test/java/com/fc8/projectboard/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/fc8/projectboard/repository/JpaRepositoryTest.java
@@ -53,7 +53,7 @@ class JpaRepositoryTest {
     void givenTestData_whenInserting_thenWorksFine() {
         // given
         long prevCount = articleRepository.count();
-        User user = userRepository.save(User.of("reddyong", "password", null, null, null));
+        User user = userRepository.save(User.of("new reddyong", "password", null, null, null));
         Article article = Article.of(user, "new article", "new content", "#newtag");
 
         // when


### PR DESCRIPTION
회원 엔티티의 userId 속성에 unique 제약 추가

This closes #31 